### PR TITLE
feat: bootstrap AuroraLLM architecture

### DIFF
--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -1,0 +1,19 @@
+# AuroraLLM Architecture
+
+AuroraLLM is a modular macOS SwiftUI application designed to run local-first.
+The architecture is split into several modules:
+
+- **UI**: SwiftUI chat interface implemented in `AuroraLLMApp`.
+- **RAGEngine**: Coordinates retrieval augmented generation. Placeholder `handleQuery()` for now.
+- **DocumentParser**: Extracts text from supported files using PDFKit and Vision OCR.
+- **Embedder**: Placeholder module responsible for converting text to vector embeddings.
+- **VectorStore**: Placeholder in-memory vector database for similarity search.
+- **LocalLLM**: Placeholder local language model interface used to generate answers.
+
+## Flow
+1. User inputs a query through the UI.
+2. `RAGEngine` embeds the query using `Embedder` and searches `VectorStore` for relevant documents.
+3. Retrieved context is sent to `LocalLLM` along with the query to produce an answer.
+4. The result is displayed back in the chat interface.
+
+Future work will implement actual embedding, vector search, and model inference.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,69 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let products: [PackageDescription.Product] = {
+    var items: [Product] = [
+        .library(name: "RAGEngine", targets: ["RAGEngine"]),
+        .library(name: "DocumentParser", targets: ["DocumentParser"]),
+        .library(name: "Embedder", targets: ["Embedder"]),
+        .library(name: "LocalLLM", targets: ["LocalLLM"]),
+        .library(name: "VectorStore", targets: ["VectorStore"])
+    ]
+    #if os(macOS)
+    items.append(.executable(name: "AuroraLLMApp", targets: ["AuroraLLMApp"]))
+    #endif
+    return items
+}()
+
+let targets: [PackageDescription.Target] = {
+    var items: [Target] = [
+        .target(
+            name: "RAGEngine",
+            dependencies: ["Embedder", "LocalLLM", "VectorStore"],
+            path: "Sources/RAGEngine"
+        ),
+        .target(
+            name: "DocumentParser",
+            path: "Sources/DocumentParser"
+        ),
+        .target(
+            name: "Embedder",
+            path: "Sources/Embedder"
+        ),
+        .target(
+            name: "LocalLLM",
+            path: "Sources/LocalLLM"
+        ),
+        .target(
+            name: "VectorStore",
+            path: "Sources/VectorStore"
+        ),
+        .testTarget(
+            name: "AuroraLLMTests",
+            dependencies: ["DocumentParser", "VectorStore"],
+            path: "Tests/AuroraLLMTests",
+            resources: [
+                .copy("Resources")
+            ]
+        )
+    ]
+    #if os(macOS)
+    items.insert(
+        .executableTarget(
+            name: "AuroraLLMApp",
+            dependencies: ["RAGEngine", "DocumentParser", "Embedder", "LocalLLM", "VectorStore"],
+            path: "Sources/AuroraLLMApp"
+        ), at: 0)
+    #endif
+    return items
+}()
+
+let package = Package(
+    name: "AuroraLLM",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: products,
+    dependencies: [],
+    targets: targets
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# AuroraLLM
+
+Prototype macOS SwiftUI application with modular architecture.
+Run `swift build` to build and `swift test` to run unit tests.

--- a/Sources/AuroraLLMApp/AuroraLLMApp.swift
+++ b/Sources/AuroraLLMApp/AuroraLLMApp.swift
@@ -1,0 +1,21 @@
+import RAGEngine
+import DocumentParser
+import Embedder
+import LocalLLM
+import VectorStore
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+#if canImport(SwiftUI)
+@main
+struct AuroraLLMApp: App {
+    @StateObject private var viewModel = ChatViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ChatView(viewModel: viewModel)
+        }
+    }
+}
+#endif

--- a/Sources/AuroraLLMApp/ChatView.swift
+++ b/Sources/AuroraLLMApp/ChatView.swift
@@ -1,0 +1,41 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+#if canImport(SwiftUI)
+struct ChatView: View {
+    @ObservedObject var viewModel: ChatViewModel
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                LazyVStack(alignment: .leading) {
+                    ForEach(viewModel.messages, id: \.self) { message in
+                        Text(message)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(4)
+                    }
+                }
+            }
+            HStack {
+                TextField("Enter message", text: $viewModel.inputText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Send") {
+                    viewModel.send()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}
+#endif
+
+#if canImport(SwiftUI)
+struct ChatView_Previews: PreviewProvider {
+    static var previews: some View {
+        ChatView(viewModel: ChatViewModel())
+    }
+}
+#endif

--- a/Sources/AuroraLLMApp/ChatViewModel.swift
+++ b/Sources/AuroraLLMApp/ChatViewModel.swift
@@ -1,0 +1,21 @@
+#if canImport(SwiftUI)
+import Foundation
+import RAGEngine
+
+final class ChatViewModel: ObservableObject {
+    @Published var inputText: String = ""
+    @Published var messages: [String] = []
+    private let engine = RAGEngine()
+
+    func send() {
+        let query = inputText
+        inputText = ""
+        messages.append("You: \(query)")
+        engine.handleQuery(query) { [weak self] response in
+            DispatchQueue.main.async {
+                self?.messages.append("Assistant: \(response)")
+            }
+        }
+    }
+}
+#endif

--- a/Sources/DocumentParser/DocumentParser.swift
+++ b/Sources/DocumentParser/DocumentParser.swift
@@ -1,0 +1,76 @@
+import Foundation
+#if canImport(PDFKit)
+import PDFKit
+#endif
+#if canImport(Vision)
+import Vision
+#endif
+
+public enum ParsedDocument {
+    case text(String)
+}
+
+public final class DocumentParser {
+    public init() {}
+
+    public func parse(url: URL) -> ParsedDocument? {
+        switch url.pathExtension.lowercased() {
+        case "pdf":
+            return parsePDF(url: url)
+        case "txt":
+            return parseTXT(url: url)
+        case "docx":
+            return parseDOCX(url: url)
+        case "png":
+            return parsePNG(url: url)
+        case "eml":
+            return parseEML(url: url)
+        default:
+            return nil
+        }
+    }
+
+#if canImport(PDFKit)
+    private func parsePDF(url: URL) -> ParsedDocument? {
+        guard let pdf = PDFDocument(url: url) else { return nil }
+        var text = ""
+        for i in 0..<pdf.pageCount {
+            if let page = pdf.page(at: i) {
+                text += page.string ?? ""
+            }
+        }
+        return .text(text)
+    }
+#else
+    private func parsePDF(url: URL) -> ParsedDocument? {
+        return nil
+    }
+#endif
+
+    private func parseTXT(url: URL) -> ParsedDocument? {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return nil }
+        return .text(text)
+    }
+
+    private func parseDOCX(url: URL) -> ParsedDocument? {
+        // TODO: implement DOCX parsing
+        return nil
+    }
+
+#if canImport(Vision)
+    private func parsePNG(url: URL) -> ParsedDocument? {
+        // TODO: implement OCR using Vision
+        return nil
+    }
+#else
+    private func parsePNG(url: URL) -> ParsedDocument? {
+        return nil
+    }
+#endif
+
+    private func parseEML(url: URL) -> ParsedDocument? {
+        // TODO: implement email parsing
+        return nil
+    }
+}

--- a/Sources/Embedder/Embedder.swift
+++ b/Sources/Embedder/Embedder.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public final class Embedder {
+    public init() {}
+
+    public func embed(text: String) -> [Double] {
+        // TODO: replace with real embedding model
+        return Array(repeating: 0.0, count: 768)
+    }
+}

--- a/Sources/LocalLLM/LocalLLM.swift
+++ b/Sources/LocalLLM/LocalLLM.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public final class LocalLLM {
+    public init() {}
+
+    public func generateAnswer(query: String, context: String) -> String {
+        // TODO: integrate local language model
+        return "Placeholder answer"
+    }
+}

--- a/Sources/RAGEngine/RAGEngine.swift
+++ b/Sources/RAGEngine/RAGEngine.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Embedder
+import LocalLLM
+import VectorStore
+
+public final class RAGEngine {
+    private let embedder = Embedder()
+    private let llm = LocalLLM()
+    private let store = VectorStore()
+
+    public init() {}
+
+    public func handleQuery(_ query: String, completion: @escaping (String) -> Void) {
+        // Placeholder implementation
+        completion("This is a stubbed response for: \(query)")
+    }
+}

--- a/Sources/VectorStore/VectorStore.swift
+++ b/Sources/VectorStore/VectorStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public final class VectorStore {
+    private var vectors: [String: [Double]] = [:]
+
+    public init() {}
+
+    public func add(id: String, vector: [Double]) {
+        vectors[id] = vector
+    }
+
+    public func nearest(to vector: [Double], count: Int = 5) -> [String] {
+        return vectors.keys.prefix(count).map { $0 }
+    }
+}

--- a/Tests/AuroraLLMTests/AuroraLLMTests.swift
+++ b/Tests/AuroraLLMTests/AuroraLLMTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import DocumentParser
+@testable import VectorStore
+
+final class AuroraLLMTests: XCTestCase {
+    func testPDFParsing() throws {
+        #if canImport(PDFKit)
+        guard let url = Bundle.module.url(forResource: "sample", withExtension: "pdf") else {
+            throw XCTSkip("Sample PDF not found")
+        }
+        let parser = DocumentParser()
+        let result = parser.parse(url: url)
+        XCTAssertNotNil(result)
+        #else
+        throw XCTSkip("PDFKit not available")
+        #endif
+    }
+
+    func testVectorSimilarity() throws {
+        let store = VectorStore()
+        store.add(id: "a", vector: [1, 0, 0])
+        let results = store.nearest(to: [0, 1, 0], count: 1)
+        XCTAssertEqual(results.count, 1)
+    }
+}

--- a/Tests/AuroraLLMTests/Resources/sample.pdf
+++ b/Tests/AuroraLLMTests/Resources/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 700 Td
+(Hello) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000054 00000 n
+0000000103 00000 n
+0000000174 00000 n
+0000000271 00000 n
+trailer
+<< /Root 1 0 R >>
+startxref
+337
+%%EOF


### PR DESCRIPTION
## Summary
- scaffold AuroraLLM Swift package with macOS SwiftUI app entry
- add modular placeholders for RAGEngine, LocalLLM, Embedder, VectorStore
- implement DocumentParser with PDFKit/Vision stubs
- provide simple chat UI and ViewModel guarded for SwiftUI availability
- add unit tests for PDF parsing and vector search
- document high level architecture

## Testing
- `swift test`